### PR TITLE
fix: more clear error message for config on localhost

### DIFF
--- a/src/netlify.js
+++ b/src/netlify.js
@@ -84,7 +84,7 @@ class Authenticator {
     }
     if (!siteID) {
       return cb(new NetlifyError({
-        message: "You must set a site_id with netlify.configure({site_id: \"your-site-id\"}) to make authentication work from localhost"
+        message: "You must set a site_id with new netlify({site_id: \"your-site-id\"}) to make authentication work from localhost"
       }));
     }
 


### PR DESCRIPTION
As far as I see, that config should be done in the `constructor`, not `configure`, maybe an older API?